### PR TITLE
inject search header into all pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ _testmain.go
 *.zim
 cmd/gozimhttpd/gozimhttpd
 cmd/gozimindex/gozimindex
+
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+

--- a/cmd/gozimhttpd/templates/search.html
+++ b/cmd/gozimhttpd/templates/search.html
@@ -52,7 +52,7 @@
 
 		<div class="jumbotron">
 			<h2>Search Terms Examples</h2>
-			<p>Terms: <code>water</code><br>Phrase: <code>"light beer"</code><br>Required and exclusion: <code>+water -light beer</code> will perform a Query that MUST match the term water, MUST NOT match for the term light in the default field, and SHOULD match the term beer.</p>
+			<p>Terms: <code>water</code><br>Phrase: <code>"vapor pressure "</code><br>Required and exclusion: <code>+water -vapor pressure</code> will perform a Query that MUST match the term water, MUST NOT match for the term light in the default field, and SHOULD match the term pressure.</p>
 		</div>
 
 		<div class="row">

--- a/cmd/gozimhttpd/templates/search.html
+++ b/cmd/gozimhttpd/templates/search.html
@@ -52,7 +52,7 @@
 
 		<div class="jumbotron">
 			<h2>Search Terms Examples</h2>
-			<p>Terms: <code>water</code><br>Phrase: <code>"vapor pressure "</code><br>Required and exclusion: <code>+water -vapor pressure</code> will perform a Query that MUST match the term water, MUST NOT match for the term light in the default field, and SHOULD match the term pressure.</p>
+			<p>Terms: <code>water</code><br>Phrase: <code>"vapor pressure"</code><br>Required and exclusion: <code>+water -vapor pressure</code> will perform a Query that MUST match the term water, MUST NOT match for the term light in the default field, and SHOULD match the term pressure.</p>
 		</div>
 
 		<div class="row">

--- a/cmd/gozimhttpd/templates/search.html
+++ b/cmd/gozimhttpd/templates/search.html
@@ -52,7 +52,7 @@
 
 		<div class="jumbotron">
 			<h2>Search Terms Examples</h2>
-			<p>Terms: <code>water</code><br>Phrase: <code>"vapor pressure"</code><br>Required and exclusion: <code>+water -vapor pressure</code> will perform a Query that MUST match the term water, MUST NOT match for the term light in the default field, and SHOULD match the term pressure.</p>
+			<p>Terms: <code>water</code><br>Phrase: <code>"vapor pressure"</code><br>Required and exclusion: <code>+water -vapor pressure</code> will perform a Query that MUST match the term water, MUST NOT match for the term vapor in the default field, and SHOULD match the term pressure.</p>
 		</div>
 
 		<div class="row">


### PR DESCRIPTION
Currently, when navigating pages, you generally lose search capabilities, which is inconvenient.  This is a  artifact from how the zim files are generated - kiwix comes with a GUI containing a search bar so they see including a search input as part of the html as redundant.  In our case, the consequence is that we lack a search bar.

To remedy, we inject some html for searching into every page when it is loaded in the http server.  We inline the search html to avoid costly disk reads.